### PR TITLE
Add source links for citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Next, enable logging on the app service. Go to "App Service logs" under Monitori
 Now, you should be able to see logs from your app by viewing "Log stream" under Monitoring.
 
 ### Changing Citation Display
-The Citation panel is defined at the end of `frontend/src/pages/chat/Chat.tsx`. The citations returned from Azure OpenAI On Your Data will include `content`, `title`, `filepath`, and in some cases `url`. You can customize the Citation section to use and display these as you like. For example, the title element is a clickable hyperlink if `url` is not a blob URL.
+The Citation panel is defined at the end of `frontend/src/pages/chat/Chat.tsx`. The citations returned from Azure OpenAI On Your Data will include `content`, `title`, `filepath`, `path`, and in some cases `url`. You can customize the Citation section to use and display these as you like. For example, the title element is a clickable hyperlink if `url` is not a blob URL.
 
 ```
     <h5 

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -14,6 +14,7 @@ export type Citation = {
   id: string
   title: string | null
   filepath: string | null
+  path?: string | null
   url: string | null
   metadata: string | null
   chunk_id: string | null

--- a/frontend/src/components/Answer/Answer.module.css
+++ b/frontend/src/components/Answer/Answer.module.css
@@ -201,3 +201,13 @@ sup {
     margin-bottom: 5px;
   }
 }
+
+.citationLink {
+  margin-left: 4px;
+  color: #115ea3;
+}
+
+.citationLink:hover {
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/frontend/src/components/Answer/Answer.tsx
+++ b/frontend/src/components/Answer/Answer.tsx
@@ -365,6 +365,15 @@ export const Answer = ({ answer, onCitationClicked, onExectResultClicked }: Prop
                   aria-label={createCitationFilepath(citation, idx)}>
                   <div className={styles.citation}>{idx}</div>
                   {createCitationFilepath(citation, idx, true)}
+                  {(citation.url || citation.path) && (
+                    <a
+                      className={styles.citationLink}
+                      href={citation.url ?? citation.path ?? undefined}
+                      target="_blank"
+                      onClick={e => e.stopPropagation()}>
+                      Source
+                    </a>
+                  )}
                 </span>
               )
             })}


### PR DESCRIPTION
## Summary
- show a Source link for each citation that opens the original file
- support an optional `path` field on citations
- document new path field in README

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: command not found)*