### PR TITLE
Add link to citation file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,16 +395,23 @@ Now, you should be able to see logs from your app by viewing "Log stream" under 
 The Citation panel is defined at the end of `frontend/src/pages/chat/Chat.tsx`. The citations returned from Azure OpenAI On Your Data will include `content`, `title`, `filepath`, `path`, and in some cases `url`. You can customize the Citation section to use and display these as you like. For example, the title element is a clickable hyperlink if `url` is not a blob URL.
 
 ```
-    <h5 
-        className={styles.citationPanelTitle} 
-        tabIndex={0} 
-        title={activeCitation.url && !activeCitation.url.includes("blob.core") ? activeCitation.url : activeCitation.title ?? ""} 
+    <h5
+        className={styles.citationPanelTitle}
+        tabIndex={0}
+        title={
+            activeCitation.url && !activeCitation.url.includes("blob.core")
+                ? activeCitation.url
+                : activeCitation.path && !activeCitation.path.includes("blob.core")
+                    ? activeCitation.path
+                    : activeCitation.title ?? ""
+        }
         onClick={() => onViewSource(activeCitation)}
     >{activeCitation.title}</h5>
 
     const onViewSource = (citation: Citation) => {
-        if (citation.url && !citation.url.includes("blob.core")) {
-            window.open(citation.url, "_blank");
+        const link = citation.url ?? citation.path ?? null;
+        if (link && !link.includes("blob.core")) {
+            window.open(link, "_blank");
         }
     };
 

--- a/frontend/src/components/Answer/Answer.tsx
+++ b/frontend/src/components/Answer/Answer.tsx
@@ -369,6 +369,7 @@ export const Answer = ({ answer, onCitationClicked, onExectResultClicked }: Prop
                     <a
                       className={styles.citationLink}
                       href={citation.url ?? citation.path ?? undefined}
+                      title={citation.url ?? citation.path ?? undefined}
                       target="_blank"
                       onClick={e => e.stopPropagation()}>
                       Source

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -713,8 +713,9 @@ const Chat = () => {
   }
 
   const onViewSource = (citation: Citation) => {
-    if (citation.url && !citation.url.includes('blob.core')) {
-      window.open(citation.url, '_blank')
+    const link = citation.url ?? citation.path ?? null
+    if (link && !link.includes('blob.core')) {
+      window.open(link, '_blank')
     }
   }
 
@@ -972,7 +973,9 @@ const Chat = () => {
                 title={
                   activeCitation.url && !activeCitation.url.includes('blob.core')
                     ? activeCitation.url
-                    : activeCitation.title ?? ''
+                    : activeCitation.path && !activeCitation.path.includes('blob.core')
+                      ? activeCitation.path
+                      : activeCitation.title ?? ''
                 }
                 onClick={() => onViewSource(activeCitation)}>
                 {activeCitation.title}


### PR DESCRIPTION
## Summary
- surface `citation.path` in `onViewSource`
- support path links in citation panel title
- display path as Source hyperlink title
- document how to open citations by path

## Testing
- `npm test --silent`
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement azure-identity==1.15.0)*