### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/frontend/src/components/common/ThemeToggle.tsx
+++ b/frontend/src/components/common/ThemeToggle.tsx
@@ -1,0 +1,12 @@
+import { IconButton } from '@fluentui/react'
+import React, { useContext } from 'react'
+import { ThemeContext } from '../../state/ThemeProvider'
+
+const ThemeToggle: React.FC = () => {
+  const { theme, toggleTheme } = useContext(ThemeContext)
+  const iconName = theme === 'light' ? 'ClearNight' : 'Sunny'
+
+  return <IconButton ariaLabel="Toggle theme" iconProps={{ iconName }} onClick={toggleTheme} />
+}
+
+export default ThemeToggle

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,26 @@
   box-sizing: border-box;
 }
 
+:root {
+  --background-color: #add8e6;
+  --text-color: #242424;
+  --header-background: #add8e6;
+  --header-text: #242424;
+  --chat-container-background: radial-gradient(108.78% 108.78% at 50.02% 19.78%, #88b7e7 57.29%, #eef6fe 100%);
+  --user-message-bg: #edf5fd;
+  --gpt-message-bg: #ffffff;
+}
+
+html[data-theme='dark'] {
+  --background-color: #1f1f1f;
+  --text-color: #f3f3f3;
+  --header-background: #333333;
+  --header-text: #ffffff;
+  --chat-container-background: #2b2b2b;
+  --user-message-bg: #3a3a3a;
+  --gpt-message-bg: #4a4a4a;
+}
+
 html,
 body {
   height: 100%;
@@ -9,8 +29,14 @@ body {
   padding: 0;
 }
 
+body {
+  background: var(--background-color);
+  color: var(--text-color);
+}
+
 html {
-  background: #add8e6;
+  background: var(--background-color);
+  color: var(--text-color);
   font-family:
     'Segoe UI',
     'Segoe UI Web (West European)',

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -7,6 +7,7 @@ import Chat from './pages/chat/Chat'
 import Layout from './pages/layout/Layout'
 import NoPage from './pages/NoPage'
 import { AppStateProvider } from './state/AppProvider'
+import { ThemeProvider } from './state/ThemeProvider'
 
 import './index.css'
 
@@ -15,14 +16,16 @@ initializeIcons()
 export default function App() {
   return (
     <AppStateProvider>
-      <HashRouter>
-        <Routes>
-          <Route path="/" element={<Layout />}>
-            <Route index element={<Chat />} />
-            <Route path="*" element={<NoPage />} />
-          </Route>
-        </Routes>
-      </HashRouter>
+      <ThemeProvider>
+        <HashRouter>
+          <Routes>
+            <Route path="/" element={<Layout />}>
+              <Route index element={<Chat />} />
+              <Route path="*" element={<NoPage />} />
+            </Route>
+          </Routes>
+        </HashRouter>
+      </ThemeProvider>
     </AppStateProvider>
   )
 }

--- a/frontend/src/pages/chat/Chat.module.css
+++ b/frontend/src/pages/chat/Chat.module.css
@@ -20,7 +20,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  background: radial-gradient(108.78% 108.78% at 50.02% 19.78%, #88b7e7 57.29%, #eef6fe 100%);
+  background: var(--chat-container-background);
   box-shadow:
     0px 2px 4px rgba(0, 0, 0, 0.14),
     0px 0px 2px rgba(0, 0, 0, 0.12);
@@ -88,7 +88,7 @@
   position: relative;
   display: flex;
   padding: 20px;
-  background: #edf5fd;
+  background: var(--user-message-bg);
   border-radius: 8px;
   box-shadow:
     0px 2px 4px rgba(0, 0, 0, 0.14),
@@ -242,7 +242,7 @@
   align-items: flex-start;
   padding: 16px 16px;
   gap: 8px;
-  background: #ffffff;
+  background: var(--gpt-message-bg);
   box-shadow:
     0px 2px 4px rgba(0, 0, 0, 0.14),
     0px 0px 2px rgba(0, 0, 0, 0.12);

--- a/frontend/src/pages/layout/Layout.module.css
+++ b/frontend/src/pages/layout/Layout.module.css
@@ -5,7 +5,7 @@
 }
 
 .header {
-  background-color: #add8e6;
+  background-color: var(--header-background);
 }
 
 .headerContainer {
@@ -28,7 +28,7 @@
   line-height: 28px;
   display: flex;
   align-items: flex-end;
-  color: #242424;
+  color: var(--header-text);
 }
 
 .headerIcon {

--- a/frontend/src/pages/layout/Layout.tsx
+++ b/frontend/src/pages/layout/Layout.tsx
@@ -7,6 +7,7 @@ import { CosmosDBStatus } from '../../api'
 import WaterLogo from '../../assets/EPWaterLogo1.ico'
 
 import { HistoryButton, ShareButton } from '../../components/common/Button'
+import ThemeToggle from '../../components/common/ThemeToggle'
 import { AppStateContext } from '../../state/AppProvider'
 
 import styles from './Layout.module.css'
@@ -53,7 +54,7 @@ const Layout = () => {
     }
   }, [copyClicked])
 
-  useEffect(() => { }, [appStateContext?.state.isCosmosDBAvailable.status])
+  useEffect(() => {}, [appStateContext?.state.isCosmosDBAvailable.status])
 
   useEffect(() => {
     const handleResize = () => {
@@ -85,13 +86,15 @@ const Layout = () => {
             </Link>
           </Stack>
           <Stack horizontal tokens={{ childrenGap: 4 }} className={styles.shareButtonContainer}>
-            {appStateContext?.state.isCosmosDBAvailable?.status !== CosmosDBStatus.NotConfigured && ui?.show_chat_history_button !== false && (
-              <HistoryButton
-                onClick={handleHistoryClick}
-                text={appStateContext?.state?.isChatHistoryOpen ? hideHistoryLabel : showHistoryLabel}
-              />
-            )}
+            {appStateContext?.state.isCosmosDBAvailable?.status !== CosmosDBStatus.NotConfigured &&
+              ui?.show_chat_history_button !== false && (
+                <HistoryButton
+                  onClick={handleHistoryClick}
+                  text={appStateContext?.state?.isChatHistoryOpen ? hideHistoryLabel : showHistoryLabel}
+                />
+              )}
             {ui?.show_share_button && <ShareButton onClick={handleShareClick} text={shareLabel} />}
+            <ThemeToggle />
           </Stack>
         </Stack>
       </header>

--- a/frontend/src/state/ThemeProvider.tsx
+++ b/frontend/src/state/ThemeProvider.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useEffect, useState, ReactNode } from 'react'
+
+type Theme = 'light' | 'dark'
+
+interface ThemeContextState {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+export const ThemeContext = createContext<ThemeContextState>({
+  theme: 'light',
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  toggleTheme: () => {}
+})
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [theme, setTheme] = useState<Theme>('light')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null
+    if (stored) {
+      setTheme(stored)
+    }
+  }, [])
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'))
+  }
+
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>
+}


### PR DESCRIPTION
## Summary
- add ThemeProvider and ThemeToggle components
- support theme colors via CSS variables
- inject ThemeProvider globally
- apply dark/light styles to layout and chat modules

## Testing
- `npm run prettier` *(fails: code style issues in repo)*
- `npm test` *(fails: jest not found)*